### PR TITLE
updating react, react-dom and react-addons-test-utils to version 15.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "react": "~15.3.0",
-    "react-dom": "~15.3.0"
+    "react": "~15.4.2",
+    "react-dom": "~15.4.2"
   },
   "devDependencies": {
     "auto-reload-brunch": "^2.0.0",
@@ -29,7 +29,7 @@
     "enzyme": "^2.6.0",
     "javascript-brunch": "^2.0.0",
     "jest": "^17.0.0",
-    "react-addons-test-utils": "^15.3.2",
+    "react-addons-test-utils": "^15.4.2",
     "uglify-js-brunch": "^2.0.0"
   }
 }


### PR DESCRIPTION
Hello Ritabrata!

I've tried to install and use the current version but got an error on the `npm test` because of the current version of `react-addons-test-utils`. For some reason the packpage was installed as `15.4.2` instead of the `15.3.2` defined on the packpage.json. 

Here's an example of the result got from the `npm test` command before the update:
![brunch_react_npm_test](https://cloud.githubusercontent.com/assets/21313/22229116/cd9f1452-e1bc-11e6-8cf2-5f331cd895aa.jpg)

Running an `npm ls` to inspect I got it:
![brunch_react_npm_ls](https://cloud.githubusercontent.com/assets/21313/22229140/f049567a-e1bc-11e6-8cbe-3b52a450e7b8.jpg)

So, in order to solve it I just updated the `react` and `react-dom` (also the `react-addons-test-utils`) to the current version 15.4.2

Best, Tailor. 
 
